### PR TITLE
Make X-XRDS-Location Header Case-Insensitive

### DIFF
--- a/yadis_discovery.go
+++ b/yadis_discovery.go
@@ -103,7 +103,7 @@ func findMetaXrdsLocation(input io.Reader) (location string, err error) {
 				content := ""
 				for _, attr := range tk.Attr {
 					if attr.Key == "http-equiv" &&
-						attr.Val == "X-XRDS-Location" {
+						strings.ToLower(attr.Val) == "x-xrds-location" {
 						ok = true
 					} else if attr.Key == "content" {
 						content = attr.Val


### PR DESCRIPTION
@yohcop pls review

* Make X-XRDS-Location Header Case-Insensitive

As [python-openid](https://github.com/openid/python-openid) support case-insensitive  ``X-XRDS-Location`` header and even use it in it's [Example](https://github.com/openid/python-openid/blob/f7e13536f0d1828d3cef5ae7a7b55cabadff37fc/examples/djopenid/templates/server/index.html#L30). Support case-insensitive ``X-XRDS-Location`` header make openid-go works well with these legacy implements.
 