### PR TITLE
Add SimpleNonceStore the ability to store multiple nonces per endpoint

### DIFF
--- a/nonce_store.go
+++ b/nonce_store.go
@@ -66,7 +66,7 @@ func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
 
 	if nonces, hasOp := d.Store[endpoint]; hasOp {
 		// Delete old nonces while we are at it.
-		newNonces := []*Nonce{}
+		newNonces := []*Nonce{{ts, s}}
 		for _, n := range nonces {
 			if n.T == ts && n.S == s {
 				// If return early, just ignore the filtered list

--- a/nonce_store_test.go
+++ b/nonce_store_test.go
@@ -23,6 +23,7 @@ func TestDefaultNonceStore(t *testing.T) {
 	accept(t, ns, "1", now30sStr+"asd")
 	reject(t, ns, "1", now30sStr+"asd") // same nonce
 	accept(t, ns, "1", now30sStr+"xxx") // different nonce
+	reject(t, ns, "1", now30sStr+"xxx") // different nonce again to verify storage of multiple nonces per endpoint
 	accept(t, ns, "2", now30sStr+"asd") // different endpoint
 
 	reject(t, ns, "1", now2mStr+"old") // too old


### PR DESCRIPTION
Currently `SimpleNonceStore` only remembers the first nonce added for an endpoint and silently discards all future nonces for that endpoint. With my patch `SimpleNonceStore` will remember multiple nonces per endpoint.

For people using the `SimpleNonceStore` in production, this is probably a **medium level security patch** that helps prevent replay attacks.