### PR TITLE
Do nonce verification per endpoint. Fixes #11.

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -181,7 +181,7 @@ func verifyDiscovered(uri *url.URL, vals url.Values, cache DiscoveryCache, gette
 
 func verifyNonce(vals url.Values, store NonceStore) error {
 	nonce := vals.Get("openid.response_nonce")
-	endpoint := vals.Get("openid.endpoint")
+	endpoint := vals.Get("openid.op_endpoint")
 	return store.Accept(endpoint, nonce)
 }
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,32 @@
+package openid
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestVerifyNonce(t *testing.T) {
+	timeStr := time.Now().UTC().Format(time.RFC3339)
+	ns := &SimpleNonceStore{Store: make(map[string][]*Nonce)}
+	v := url.Values{}
+
+	// Initial values
+	v.Set("openid.op_endpoint", "1")
+	v.Set("openid.response_nonce", timeStr+"foo")
+	if err := verifyNonce(v, ns); err != nil {
+		t.Errorf("verifyNonce failed unexpectedly: %v", err)
+	}
+
+	// Different nonce
+	v.Set("openid.response_nonce", timeStr+"bar")
+	if err := verifyNonce(v, ns); err != nil {
+		t.Errorf("verifyNonce failed unexpectedly: %v", err)
+	}
+
+	// Different endpoint
+	v.Set("openid.op_endpoint", "2")
+	if err := verifyNonce(v, ns); err != nil {
+		t.Errorf("verifyNonce failed unexpectedly: %v", err)
+	}
+}


### PR DESCRIPTION
Currently nonces are verified in a universal set for all endpoints. This is unnecessarily strict and can cause false negatives. That is, currently completely valid auth attempts can fail verification if another endpoint has used the same nonce.

This was reported in #11 and thus this patch resolves that issue.