### PR TITLE
OP Identifier Element has priority over Claimed Identifier Element.

### DIFF
--- a/xrds.go
+++ b/xrds.go
@@ -36,32 +36,35 @@ func parseXrds(input []byte) (opEndpoint, opLocalID string, err error) {
 		return "", "", errors.New("XRDS document missing XRD tag")
 	}
 
+	// 7.3.2.2.  Extracting Authentication Data
+	// Once the Relying Party has obtained an XRDS document, it
+	// MUST first search the document (following the rules
+	// described in [XRI_Resolution_2.0]) for an OP Identifier
+	// Element. If none is found, the RP will search for a Claimed
+	// Identifier Element.
 	for _, service := range xrdsDoc.Xrd.Service {
-		// 7.3.2.2.  Extracting Authentication Data
-		// Once the Relying Party has obtained an XRDS document, it
-		// MUST first search the document (following the rules
-		// described in [XRI_Resolution_2.0]) for an OP Identifier
-		// Element. If none is found, the RP will search for a Claimed
-		// Identifier Element.
+		// 7.3.2.1.1.  OP Identifier Element
+		// An OP Identifier Element is an <xrd:Service> element with the
+		// following information:
+		// An <xrd:Type> tag whose text content is
+		//     "http://specs.openid.net/auth/2.0/server".
+		// An <xrd:URI> tag whose text content is the OP Endpoint URL
 		if service.hasType("http://specs.openid.net/auth/2.0/server") {
-			// 7.3.2.1.1.  OP Identifier Element
-			// An OP Identifier Element is an <xrd:Service> element with the
-			// following information:
-			// An <xrd:Type> tag whose text content is
-			//     "http://specs.openid.net/auth/2.0/server".
-			// An <xrd:URI> tag whose text content is the OP Endpoint URL
 			opEndpoint = strings.TrimSpace(service.URI)
 			return
-		} else if service.hasType("http://specs.openid.net/auth/2.0/signon") {
-			// 7.3.2.1.2.  Claimed Identifier Element
-			// A Claimed Identifier Element is an <xrd:Service> element
-			// with the following information:
-			// An <xrd:Type> tag whose text content is
-			//     "http://specs.openid.net/auth/2.0/signon".
-			// An <xrd:URI> tag whose text content is the OP Endpoint
-			//     URL.
-			// An <xrd:LocalID> tag (optional) whose text content is the
-			//     OP-Local Identifier.
+		}
+	}
+	for _, service := range xrdsDoc.Xrd.Service {
+		// 7.3.2.1.2.  Claimed Identifier Element
+		// A Claimed Identifier Element is an <xrd:Service> element
+		// with the following information:
+		// An <xrd:Type> tag whose text content is
+		//     "http://specs.openid.net/auth/2.0/signon".
+		// An <xrd:URI> tag whose text content is the OP Endpoint
+		//     URL.
+		// An <xrd:LocalID> tag (optional) whose text content is the
+		//     OP-Local Identifier.
+		if service.hasType("http://specs.openid.net/auth/2.0/signon") {
 			opEndpoint = strings.TrimSpace(service.URI)
 			opLocalID = strings.TrimSpace(service.LocalID)
 			return

--- a/xrds_test.go
+++ b/xrds_test.go
@@ -48,6 +48,26 @@ xmlns:openid="http://openid.net/xmlns/1.0">
     `),
 		"https://www.exampleprovider.com/endpoint/",
 		"https://exampleuser.exampleprovider.com/")
+
+	// OP Identifier Element has priority over Claimed Identifier Element
+	testExpectOpID(t, []byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)"
+xmlns:openid="http://openid.net/xmlns/1.0">
+  <XRD>
+    <Service xmlns="xri://$xrd*($v*2.0)">
+      <Type>http://specs.openid.net/auth/2.0/signon</Type>
+      <URI>https://www.exampleprovider.com/endpoint-signon/</URI>
+    </Service>
+    <Service xmlns="xri://$xrd*($v*2.0)">
+      <Type>http://specs.openid.net/auth/2.0/server</Type>
+      <URI>https://www.exampleprovider.com/endpoint-server/</URI>
+    </Service>
+  </XRD>
+</xrds:XRDS>
+    `),
+		"https://www.exampleprovider.com/endpoint-server/",
+		"")
 }
 
 func testExpectOpID(t *testing.T, xrds []byte, op, id string) {


### PR DESCRIPTION
The [OpenID 2.0 spec point 7.3.2.2](http://openid.net/specs/openid-authentication-2_0.html#discovery) states that "*... MUST first search the document [...] for an OP Identifier Element. If none is found, the RP will search for a Claimed Identifier Element.*"

Currently the code uses whichever one of those two comes first in the XRD. This patch implements the correct search order.