### PR TITLE
Correctly check openid.identity when verifying discovered information

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -154,7 +154,7 @@ func verifyDiscovered(uri *url.URL, vals url.Values, cache DiscoveryCache, gette
 	// Identifier in the response to make sure that the OP is authorized to
 	// make assertions about the Claimed Identifier.
 	if discovered == nil ||
-		discoveredClaimedID ==
+		discoveredLocalID ==
 			"http://specs.openid.net/auth/2.0/identifier_select" ||
 		claimedIDVerify != discoveredClaimedID {
 		if ep, lid, dci, err := discover(claimedID, getter); err == nil {


### PR DESCRIPTION
The [OpenID 2.0 spec point 11.2](http://openid.net/specs/openid-authentication-2_0.html#verify_disco) states that "*... the "openid.identity" in the request was "http://specs.openid.net/auth/2.0/identifier_select" ...*"

Currently the code compares that URL against `openid.claimed_id`. This patch implements the correct comparsion against `openid.identity`.