### PR TITLE
Normalize the Identifier before discovery.

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -26,6 +26,11 @@ const identifierSelect = "http://specs.openid.net/auth/2.0/identifier_select"
 
 // Same as the above public Discover function, but test-friendly.
 func discover(id string, getter httpGetter) (opEndpoint, opLocalID, claimedID string, err error) {
+	// From OpenID specs, 7.2: Normalization
+	if id, err = Normalize(id); err != nil {
+		return
+	}
+
 	// From OpenID specs, 7.3: Discovery.
 
 	// If the identifier is an XRI, [XRI_Resolution_2.0] will yield an

--- a/discover_test.go
+++ b/discover_test.go
@@ -6,6 +6,8 @@ import (
 
 func TestDiscoverWithYadis(t *testing.T) {
 	// They all redirect to the same XRDS document
+	expectOpIDErr(t, "example.com/xrds",
+		"foo", identifierSelect, identifierSelect, false)
 	expectOpIDErr(t, "http://example.com/xrds",
 		"foo", identifierSelect, identifierSelect, false)
 	expectOpIDErr(t, "http://example.com/xrds-loc",


### PR DESCRIPTION
The [OpenID 2.0 spec point 7.2](http://openid.net/specs/openid-authentication-2_0.html#normalization) states that "*The end user's input MUST be normalized into an Identifier ...*"

The current code does contain a function that does the normalizing, however it isn't used anywhere, not even in the example. This patch adds normalization to the start of discovery to meet the spec requirement.