### PR TITLE
Steam specific additions

### DIFF
--- a/_example/login.html
+++ b/_example/login.html
@@ -29,6 +29,11 @@
         </button>
       </li>
       <li>
+        <button onclick="return setId('http://steamcommunity.com/openid')">
+          Steam
+        </button>
+      </li>
+      <li>
         <!-- 
           OpenID 2.0 Spec point 7.1 http://openid.net/specs/openid-authentication-2_0.html#initiation
           

--- a/_example/server.go
+++ b/_example/server.go
@@ -39,7 +39,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 func discoverHandler(w http.ResponseWriter, r *http.Request) {
 	if url, err := openid.RedirectURL(r.FormValue("id"),
 		"http://localhost:8080/openidcallback",
-		""); err == nil {
+		"http://localhost:8080/"); err == nil {
 		http.Redirect(w, r, url, 303)
 	} else {
 		log.Print(err)

--- a/integration/discovery_test.go
+++ b/integration/discovery_test.go
@@ -23,6 +23,13 @@ func TestYohcop(t *testing.T) {
 		"http://yohcop.net")
 }
 
+func TestSteam(t *testing.T) {
+	expectDiscovery(t, "http://steamcommunity.com/openid",
+		"https://steamcommunity.com/openid/login",
+		"http://specs.openid.net/auth/2.0/identifier_select",
+		"http://specs.openid.net/auth/2.0/identifier_select")
+}
+
 func expectDiscovery(t *testing.T, uri, expectOp, expectLocalId, expectClaimedId string) {
 	endpoint, localId, claimedId, err := Discover(uri)
 	if err != nil {


### PR DESCRIPTION
[Steam](https://en.wikipedia.org/wiki/Steam_(software)) seems to be one of the last major OpenID 2.0 providers with absolutely no alternative auth method publicly planned. Thus I expect a good chunk of new users of this library to use it for Steam.

There's some anecdotal evidence of this in issue #11, in [random reddit threads](https://www.reddit.com/r/golang/comments/36lf6o/golang_and_openid/) mentioning using this library with Steam, and I myself am planning on using it exclusively for Steam.

This patch introduces some Steam specific additions.
1) A real-world discover test.
2) A predefined button in the example.
3) A defined realm in the example. Steam makes this a mandatory parameter. Having it in the example will make life easier for Steam users, while having no negative effect on others.