### PR TITLE
Properly check if all the required fields have been signed

### DIFF
--- a/verify_test.go
+++ b/verify_test.go
@@ -30,3 +30,65 @@ func TestVerifyNonce(t *testing.T) {
 		t.Errorf("verifyNonce failed unexpectedly: %v", err)
 	}
 }
+
+func TestVerifySignedFields(t *testing.T) {
+	// No claimed_id/identity, properly signed
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,return_to,response_nonce,assoc_handle"}},
+		true)
+
+	// Everything properly signed, even empty claimed_id/identity
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle"}},
+		true)
+
+	// With claimed_id/identity, properly signed
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		true)
+
+	// With claimed_id/identity, but those two not signed
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,return_to,response_nonce,assoc_handle"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		false)
+
+	// Missing signature for op_endpoint
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,claimed_id,identity,return_to,response_nonce,assoc_handle"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		false)
+
+	// Missing signature for return_to
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,claimed_id,identity,response_nonce,assoc_handle"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		false)
+
+	// Missing signature for response_nonce
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,claimed_id,identity,return_to,assoc_handle"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		false)
+
+	// Missing signature for assoc_handle
+	doVerifySignedFields(t,
+		url.Values{"openid.signed": []string{"signed,op_endpoint,claimed_id,identity,return_to,response_nonce"},
+			"openid.claimed_id": []string{"foo"},
+			"openid.identity":   []string{"foo"}},
+		false)
+}
+
+func doVerifySignedFields(t *testing.T, v url.Values, succeed bool) {
+	if err := verifySignedFields(v); err == nil && !succeed {
+		t.Errorf("verifySignedFields succeeded unexpectedly: %v - %v", v, err)
+	} else if err != nil && succeed {
+		t.Errorf("verifySignedFields failed unexpectedly: %v - %v", v, err)
+	}
+}


### PR DESCRIPTION
The [OpenID 2.0 spec point 10.1](http://openid.net/specs/openid-authentication-2_0.html#positive_assertions) states that "*[openid.signed] MUST contain at least "op_endpoint", "return_to" "response_nonce" and "assoc_handle", and if present in the response, "claimed_id" and "identity".*"

Currently the code doesn't verify any of this. This patch implements this verification.

This is a **high level security vulnerability**.

One attack scenario being where the attacker acquires a legitimate positive assertion without the `claimed_id` field. Then intercepting the browser redirect to the callback and adding their own malicious `claimed_id` field. All verifications pass and the malicious `claimed_id` is treated as verified.

I wrote a crude proof of concept exploit for this and tested it on the Steam OpenID Authentication server. Steam happily confirmed my `check_authentication` request because all the signed fields were legitimate and the nonce was new & unused. Steam had access to my malicious parameters (because they are sent as part of the spec requirement), but because the spec doesn't seem to require the OP to look for such attacks, ignored them.