### PR TITLE
Remove the defunct Google button from the example

### DIFF
--- a/_example/login.html
+++ b/_example/login.html
@@ -19,11 +19,6 @@
     <h2>Sign in with:</h2>
     <ul>
       <li>
-        <button onclick="return setId('https://www.google.com/accounts/o8/id')">
-          Google
-        </button>
-      </li>
-      <li>
         <button onclick="return setId('https://me.yahoo.com')">
           Yahoo!
         </button>


### PR DESCRIPTION
As mentioned in #16 - Google has [stopped supporting OpenID 2.0](https://developers.google.com/identity/protocols/OpenID2Migration?hl=en).

This patch removes the now defunct button from the example page.