### PR TITLE
Do signature verification earlier

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -32,6 +32,11 @@ func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore Nonc
 		return "", err
 	}
 
+	// - The signature on the assertion is valid (Section 11.4)
+	if err = verifySignature(uri, values, getter); err != nil {
+		return "", err
+	}
+
 	// - The value of "openid.return_to" matches the URL of the current
 	//   request (Section 11.1)
 	if err = verifyReturnTo(parsedURL, values); err != nil {
@@ -47,12 +52,6 @@ func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore Nonc
 	// - An assertion has not yet been accepted from this OP with the
 	//   same value for "openid.response_nonce" (Section 11.3)
 	if err = verifyNonce(values, nonceStore); err != nil {
-		return "", err
-	}
-
-	// - The signature on the assertion is valid and all fields that are
-	//   required to be signed are signed (Section 11.4)
-	if err = verifySignature(uri, values, getter); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
This patch moves the signature verification step to an earlier time. This was also discussed briefly in #26.

Currently `verifySignature` is called after `verifyNonce`, which means that the nonce store can be polluted with garbage that doesn't have a verified signature. Doing `verifyNonce` as the last step is a simple solution to this problem.

The [OpenID 2.0 spec point 11](http://openid.net/specs/openid-authentication-2_0.html#verification), which covers verification, doesn't demand any specific order of these verification sub-steps. These steps are all additive, so changing the order to suit our implementation specific needs is perfectly valid.