### PR TITLE
Make simple nonce store more foolproof

### DIFF
--- a/_example/server.go
+++ b/_example/server.go
@@ -14,8 +14,7 @@ const dataDir = "_example/"
 // free it. Use your own implementation, on a better database system.
 // If you have multiple servers for example, you may need to share at least
 // the nonceStore between them.
-var nonceStore = &openid.SimpleNonceStore{
-	Store: make(map[string][]*openid.Nonce)}
+var nonceStore = openid.NewSimpleNonceStore()
 var discoveryCache = &openid.SimpleDiscoveryCache{}
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {

--- a/nonce_store.go
+++ b/nonce_store.go
@@ -30,6 +30,10 @@ type SimpleNonceStore struct {
 	mutex sync.Mutex
 }
 
+func NewSimpleNonceStore() *SimpleNonceStore {
+	return &SimpleNonceStore{Store: map[string][]*Nonce{}}
+}
+
 func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
 	// Value: A string 255 characters or less in length, that MUST be
 	// unique to this particular successful authentication response.

--- a/nonce_store.go
+++ b/nonce_store.go
@@ -13,8 +13,6 @@ var maxNonceAge = flag.Duration("openid-max-nonce-age",
 	"Maximum accepted age for openid nonces. The bigger, the more"+
 		"memory is needed to store used nonces.")
 
-var nonceStore = &SimpleNonceStore{Store: make(map[string][]*Nonce)}
-
 type NonceStore interface {
 	// Returns nil if accepted, an error otherwise.
 	Accept(endpoint, nonce string) error

--- a/nonce_store.go
+++ b/nonce_store.go
@@ -24,12 +24,12 @@ type Nonce struct {
 }
 
 type SimpleNonceStore struct {
-	Store map[string][]*Nonce
+	store map[string][]*Nonce
 	mutex *sync.Mutex
 }
 
 func NewSimpleNonceStore() *SimpleNonceStore {
-	return &SimpleNonceStore{Store: map[string][]*Nonce{}, mutex: &sync.Mutex{}}
+	return &SimpleNonceStore{store: map[string][]*Nonce{}, mutex: &sync.Mutex{}}
 }
 
 func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
@@ -66,7 +66,7 @@ func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if nonces, hasOp := d.Store[endpoint]; hasOp {
+	if nonces, hasOp := d.store[endpoint]; hasOp {
 		// Delete old nonces while we are at it.
 		newNonces := []*Nonce{{ts, s}}
 		for _, n := range nonces {
@@ -79,9 +79,9 @@ func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
 				newNonces = append(newNonces, n)
 			}
 		}
-		d.Store[endpoint] = newNonces
+		d.store[endpoint] = newNonces
 	} else {
-		d.Store[endpoint] = []*Nonce{{ts, s}}
+		d.store[endpoint] = []*Nonce{{ts, s}}
 	}
 	return nil
 }

--- a/nonce_store.go
+++ b/nonce_store.go
@@ -25,11 +25,11 @@ type Nonce struct {
 
 type SimpleNonceStore struct {
 	Store map[string][]*Nonce
-	mutex sync.Mutex
+	mutex *sync.Mutex
 }
 
 func NewSimpleNonceStore() *SimpleNonceStore {
-	return &SimpleNonceStore{Store: map[string][]*Nonce{}}
+	return &SimpleNonceStore{Store: map[string][]*Nonce{}, mutex: &sync.Mutex{}}
 }
 
 func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {

--- a/nonce_store_test.go
+++ b/nonce_store_test.go
@@ -16,7 +16,7 @@ func TestDefaultNonceStore(t *testing.T) {
 	now30sStr := now30s.Format(time.RFC3339)
 	now2mStr := now2m.Format(time.RFC3339)
 
-	ns := &SimpleNonceStore{Store: make(map[string][]*Nonce)}
+	ns := NewSimpleNonceStore()
 	reject(t, ns, "1", "foo")                        // invalid nonce
 	reject(t, ns, "1", "fooBarBazLongerThan20Chars") // invalid nonce
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestVerifyNonce(t *testing.T) {
 	timeStr := time.Now().UTC().Format(time.RFC3339)
-	ns := &SimpleNonceStore{Store: make(map[string][]*Nonce)}
+	ns := NewSimpleNonceStore()
 	v := url.Values{}
 
 	// Initial values


### PR DESCRIPTION
This patch is about making the simple nonce store more resilient against failure.

1) Added a new `NewSimpleNonceStore` function that returns `*SimpleNonceStore`.

The `SimpleNonceStore` instance creation is already quite a bit of code. Even more so after this patch and with package prefixes. By having people just call `NewSimpleNonceStore` is idiomatic Go code and gives less room for failure.

2) Changed the `SimpleNonceStore` mutex to a pointer to a mutex.

The example code did everything correctly with the regular mutex, but it's easier to hurt oneself with a regular mutex here when writing new code. If a user would pass around a `SimpleNonceStore` instead of `*SimpleNonceStore`, everything would compile and even run! A copy of a `SimpleNonceStore` instance still satisfies the `NonceStore` interface, and as a `map` is a pointer, the new instance will still point to the same internal nonce store map. However it would have a copy of the mutex state. Depending on when exactly the copy was made, there would either be unsynchronized access to the map (same as without a mutex), or a deadlock as no goroutine would unlock this new copy of a locked mutex.

3) Made the `SimpleNonceStore` internal storage `map` private.

Exposing the `map` but not the mutex doesn't make sense, as this means only dangerous unsynchronized access is possible. Making it private means the `SimpleNonceStore` methods can ensure all access is properly synchronized.