### PR TITLE
Add synchronization to the simple discovery cache

### DIFF
--- a/_example/server.go
+++ b/_example/server.go
@@ -16,7 +16,7 @@ const dataDir = "_example/"
 // the nonceStore between them.
 var nonceStore = &openid.SimpleNonceStore{
 	Store: make(map[string][]*openid.Nonce)}
-var discoveryCache = &openid.SimpleDiscoveryCache{}
+var discoveryCache = openid.NewSimpleDiscoveryCache()
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	p := make(map[string]string)

--- a/discovery_cache_test.go
+++ b/discovery_cache_test.go
@@ -1,0 +1,24 @@
+package openid
+
+import (
+	"testing"
+)
+
+func TestDiscoveryCache(t *testing.T) {
+	dc := NewSimpleDiscoveryCache()
+
+	// Put some initial values
+	dc.Put("foo", &SimpleDiscoveredInfo{opEndpoint: "a", opLocalID: "b", claimedID: "c"})
+
+	// Make sure we can retrieve them
+	if di := dc.Get("foo"); di == nil {
+		t.Errorf("Expected a result, got nil")
+	} else if di.OpEndpoint() != "a" || di.OpLocalID() != "b" || di.ClaimedID() != "c" {
+		t.Errorf("Expected a b c, got %v %v %v", di.OpEndpoint(), di.OpLocalID(), di.ClaimedID())
+	}
+
+	// Attempt to get a non-existent value
+	if di := dc.Get("bar"); di != nil {
+		t.Errorf("Expected nil, got %v", di)
+	}
+}


### PR DESCRIPTION
The `SimpleDiscoveryCache` has the same synchronization requirements as `SimpleNonceStore`. I have now solved it the same way as it has been solved for the nonce store, with mutexes guarding the map.

I also added a new convenience function `NewSimpleDiscoveryCache`, similarly to the nonce store, for easy instance creation.