### PR TITLE
Also inspect SelfClosingTagTokens

### DIFF
--- a/html_discovery.go
+++ b/html_discovery.go
@@ -30,7 +30,7 @@ func findProviderFromHeadLink(input io.Reader) (opEndpoint, opLocalID string, er
 				return
 			}
 			return "", "", tokenizer.Err()
-		case html.StartTagToken, html.EndTagToken:
+		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
 			tk := tokenizer.Token()
 			if tk.Data == "head" {
 				if tt == html.StartTagToken {


### PR DESCRIPTION
Some OpenID servers use `<link rel="openid2.provider" href="https://path/to/openidserver/" />`, which is a self-closing tag and doesn't get picked up.