### PR TITLE
Use a relative import path for integration tests

### DIFF
--- a/integration/discovery_test.go
+++ b/integration/discovery_test.go
@@ -5,7 +5,7 @@ package integration
 // whatever, they will fail. It's ok though, they are full tests.
 
 import (
-	. "github.com/yohcop/openid-go"
+	. "../"
 	"testing"
 )
 


### PR DESCRIPTION
This patch would make it easier to develop & test this library in folders other than `github.com/yohcop/openid-go`. For example I do development in my own unstable branches that aren't even located in GOPATH. The integration tests still point towards the master yohcop branch. This patch makes the import relative, allowing it to work in all sorts of configurations.