### PR TITLE
Fix authentication request parameter building

### DIFF
--- a/redirect.go
+++ b/redirect.go
@@ -23,17 +23,25 @@ func buildRedirectURL(opEndpoint, opLocalID, claimedID, returnTo, realm string) 
 	values.Add("openid.mode", "checkid_setup")
 	values.Add("openid.return_to", returnTo)
 
+	// 9.1.  Request Parameters
+	// "openid.claimed_id" and "openid.identity" SHALL be either both present or both absent.
 	if len(claimedID) > 0 {
 		values.Add("openid.claimed_id", claimedID)
 		if len(opLocalID) > 0 {
 			values.Add("openid.identity", opLocalID)
 		} else {
-			values.Add("openid.identity",
-				"http://specs.openid.net/auth/2.0/identifier_select")
+			// If a different OP-Local Identifier is not specified,
+			// the claimed identifier MUST be used as the value for openid.identity.
+			values.Add("openid.identity", claimedID)
 		}
 	} else {
-		values.Add("openid.identity",
-			"http://specs.openid.net/auth/2.0/identifier_select")
+		// 7.3.1.  Discovered Information
+		// If the end user entered an OP Identifier, there is no Claimed Identifier.
+		// For the purposes of making OpenID Authentication requests, the value
+		// "http://specs.openid.net/auth/2.0/identifier_select" MUST be used as both the
+		// Claimed Identifier and the OP-Local Identifier when an OP Identifier is entered.
+		values.Add("openid.claimed_id", "http://specs.openid.net/auth/2.0/identifier_select")
+		values.Add("openid.identity", "http://specs.openid.net/auth/2.0/identifier_select")
 	}
 
 	if len(realm) > 0 {

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -22,12 +22,22 @@ func TestBuildRedirectUrl(t *testing.T) {
 			"&openid.return_to=returnTo"+
 			"&openid.claimed_id=claimedId"+
 			"&openid.identity=opLocalId")
+	// No realm, no localId
+	expectURL(t, "https://endpoint/a", "", "claimedId", "returnTo", "",
+		"https://endpoint/a?"+
+			"openid.ns=http://specs.openid.net/auth/2.0"+
+			"&openid.mode=checkid_setup"+
+			"&openid.return_to=returnTo"+
+			"&openid.claimed_id=claimedId"+
+			"&openid.identity=claimedId")
 	// No realm, no claimedId
 	expectURL(t, "https://endpoint/a", "opLocalId", "", "returnTo", "",
 		"https://endpoint/a?"+
 			"openid.ns=http://specs.openid.net/auth/2.0"+
 			"&openid.mode=checkid_setup"+
 			"&openid.return_to=returnTo"+
+			"&openid.claimed_id="+
+			"http://specs.openid.net/auth/2.0/identifier_select"+
 			"&openid.identity="+
 			"http://specs.openid.net/auth/2.0/identifier_select")
 }


### PR DESCRIPTION
The authentication request wasn't being built according to the spec. It managed to still somewhat work mostly due to implementation quirks in other parts of the library.

The [OpenID 2.0 spec point 7.3.1](http://openid.net/specs/openid-authentication-2_0.html#discovery) states that *"http://specs.openid.net/auth/2.0/identifier_select" MUST be used as both the Claimed Identifier and the OP-Local Identifier when an OP Identifier is entered*. Previously only the local id was being set to this URL in such a case. (Due to implementation quirks, this code path is actually dead. I will address this in a future pull request.)

The [OpenID 2.0 spec point 9.1](http://openid.net/specs/openid-authentication-2_0.html#anchor27) states that *If a different OP-Local Identifier is not specified, the claimed identifier MUST be used as the value for openid.identity*. Previously the `identifier_select` URL was mistakenly used instead.