### PR TITLE
Don't override discovered ids with identifier_select URLs

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -22,8 +22,6 @@ func Discover(id string) (opEndpoint, opLocalID, claimedID string, err error) {
 	return discover(id, urlGetter)
 }
 
-const identifierSelect = "http://specs.openid.net/auth/2.0/identifier_select"
-
 // Same as the above public Discover function, but test-friendly.
 func discover(id string, getter httpGetter) (opEndpoint, opLocalID, claimedID string, err error) {
 	// From OpenID specs, 7.2: Normalization
@@ -55,11 +53,6 @@ func discover(id string, getter httpGetter) (opEndpoint, opLocalID, claimedID st
 
 	if err != nil {
 		return "", "", "", err
-	}
-
-	if claimedID == "" {
-		claimedID = identifierSelect
-		opLocalID = identifierSelect
 	}
 	return
 }

--- a/discover_test.go
+++ b/discover_test.go
@@ -7,13 +7,13 @@ import (
 func TestDiscoverWithYadis(t *testing.T) {
 	// They all redirect to the same XRDS document
 	expectOpIDErr(t, "example.com/xrds",
-		"foo", identifierSelect, identifierSelect, false)
+		"foo", "bar", "", false)
 	expectOpIDErr(t, "http://example.com/xrds",
-		"foo", identifierSelect, identifierSelect, false)
+		"foo", "bar", "", false)
 	expectOpIDErr(t, "http://example.com/xrds-loc",
-		"foo", identifierSelect, identifierSelect, false)
+		"foo", "bar", "", false)
 	expectOpIDErr(t, "http://example.com/xrds-meta",
-		"foo", identifierSelect, identifierSelect, false)
+		"foo", "bar", "", false)
 }
 
 func TestDiscoverWithHtml(t *testing.T) {

--- a/integration/discovery_test.go
+++ b/integration/discovery_test.go
@@ -12,8 +12,8 @@ import (
 func TestYahoo(t *testing.T) {
 	expectDiscovery(t, "https://me.yahoo.com",
 		"https://open.login.yahooapis.com/openid/op/auth",
-		"http://specs.openid.net/auth/2.0/identifier_select",
-		"http://specs.openid.net/auth/2.0/identifier_select")
+		"",
+		"")
 }
 
 func TestYohcop(t *testing.T) {
@@ -26,8 +26,8 @@ func TestYohcop(t *testing.T) {
 func TestSteam(t *testing.T) {
 	expectDiscovery(t, "http://steamcommunity.com/openid",
 		"https://steamcommunity.com/openid/login",
-		"http://specs.openid.net/auth/2.0/identifier_select",
-		"http://specs.openid.net/auth/2.0/identifier_select")
+		"",
+		"")
 }
 
 func expectDiscovery(t *testing.T, uri, expectOp, expectLocalId, expectClaimedId string) {


### PR DESCRIPTION
The [OpenID 2.0 spec point 7.3.1](http://openid.net/specs/openid-authentication-2_0.html#discovery) states that *For the purposes of making OpenID Authentication requests, the value "http://specs.openid.net/auth/2.0/identifier_select" MUST be used as both the Claimed Identifier and the OP-Local Identifier when an OP Identifier is entered*.

This authentication request is being built in the `buildRedirectURL` function in the `redirect.go` file. The `identifier_select` URL is assigned there as needed. The `discover` function does not need to return this.