### PR TITLE
Making http.Client configurable on a per-instance basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ directory, like so:
 
     go run _example/server.go
 
+## App Engine
+
+In order to use this on Google App Engine, you need to create an instance with a custom `*http.Client` provided by [urlfetch](https://cloud.google.com/appengine/docs/go/urlfetch/).
+
+```go
+oid := openid.NewOpenID(urlfetch.Client(appengine.NewContext(r)))
+oid.RedirectURL(...)
+oid.Verify(...)
+```
+
 ## License
 
 Distributed under the [Apache v2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/discover.go
+++ b/discover.go
@@ -19,7 +19,11 @@ package openid
 // used as both the Claimed Identifier and the OP-Local Identifier
 // when an OP Identifier is entered.
 func Discover(id string) (opEndpoint, opLocalID, claimedID string, err error) {
-	return discover(id, urlGetter)
+	return defaultInstance.Discover(id)
+}
+
+func (oid *OpenID) Discover(id string) (opEndpoint, opLocalID, claimedID string, err error) {
+	return discover(id, oid.urlGetter)
 }
 
 // Same as the above public Discover function, but test-friendly.

--- a/discover.go
+++ b/discover.go
@@ -23,11 +23,6 @@ func Discover(id string) (opEndpoint, opLocalID, claimedID string, err error) {
 }
 
 func (oid *OpenID) Discover(id string) (opEndpoint, opLocalID, claimedID string, err error) {
-	return discover(id, oid.urlGetter)
-}
-
-// Same as the above public Discover function, but test-friendly.
-func discover(id string, getter httpGetter) (opEndpoint, opLocalID, claimedID string, err error) {
 	// From OpenID specs, 7.2: Normalization
 	if id, err = Normalize(id); err != nil {
 		return
@@ -47,12 +42,12 @@ func discover(id string, getter httpGetter) (opEndpoint, opLocalID, claimedID st
 	// If it is a URL, the Yadis protocol [Yadis] SHALL be first
 	// attempted. If it succeeds, the result is again an XRDS
 	// document.
-	if opEndpoint, opLocalID, err = yadisDiscovery(id, getter); err != nil {
+	if opEndpoint, opLocalID, err = yadisDiscovery(id, oid.urlGetter); err != nil {
 		// If the Yadis protocol fails and no valid XRDS document is
 		// retrieved, or no Service Elements are found in the XRDS
 		// document, the URL is retrieved and HTML-Based discovery SHALL be
 		// attempted.
-		opEndpoint, opLocalID, claimedID, err = htmlDiscovery(id, getter)
+		opEndpoint, opLocalID, claimedID, err = htmlDiscovery(id, oid.urlGetter)
 	}
 
 	if err != nil {

--- a/discover_test.go
+++ b/discover_test.go
@@ -33,7 +33,7 @@ func TestDiscoverBadUrl(t *testing.T) {
 }
 
 func expectOpIDErr(t *testing.T, uri, exOpEndpoint, exOpLocalID, exClaimedID string, exErr bool) {
-	opEndpoint, opLocalID, claimedID, err := discover(uri, testGetter)
+	opEndpoint, opLocalID, claimedID, err := testInstance.Discover(uri)
 	if (err != nil) != exErr {
 		t.Errorf("Unexpected error: '%s'", err)
 	} else {

--- a/fake_getter_test.go
+++ b/fake_getter_test.go
@@ -16,6 +16,8 @@ type fakeGetter struct {
 var testGetter = &fakeGetter{
 	make(map[string]string), make(map[string]string)}
 
+var testInstance = &OpenID{urlGetter: testGetter}
+
 func (f *fakeGetter) Get(uri string, headers map[string]string) (resp *http.Response, err error) {
 	key := uri
 	for k, v := range headers {

--- a/getter.go
+++ b/getter.go
@@ -11,11 +11,11 @@ type httpGetter interface {
 	Post(uri string, form url.Values) (resp *http.Response, err error)
 }
 
-type defaultGetter struct{}
+type defaultGetter struct {
+	client *http.Client
+}
 
-var urlGetter = &defaultGetter{}
-
-func (*defaultGetter) Get(uri string, headers map[string]string) (resp *http.Response, err error) {
+func (dg *defaultGetter) Get(uri string, headers map[string]string) (resp *http.Response, err error) {
 	request, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return
@@ -23,10 +23,9 @@ func (*defaultGetter) Get(uri string, headers map[string]string) (resp *http.Res
 	for h, v := range headers {
 		request.Header.Add(h, v)
 	}
-	client := &http.Client{}
-	return client.Do(request)
+	return dg.client.Do(request)
 }
 
-func (*defaultGetter) Post(uri string, form url.Values) (resp *http.Response, err error) {
-	return http.PostForm(uri, form)
+func (dg *defaultGetter) Post(uri string, form url.Values) (resp *http.Response, err error) {
+	return dg.client.PostForm(uri, form)
 }

--- a/openid.go
+++ b/openid.go
@@ -1,0 +1,15 @@
+package openid
+
+import (
+	"net/http"
+)
+
+type OpenID struct {
+	urlGetter httpGetter
+}
+
+func NewOpenID(client *http.Client) *OpenID {
+	return &OpenID{urlGetter: &defaultGetter{client: client}}
+}
+
+var defaultInstance = NewOpenID(http.DefaultClient)

--- a/redirect.go
+++ b/redirect.go
@@ -10,11 +10,7 @@ func RedirectURL(id, callbackURL, realm string) (string, error) {
 }
 
 func (oid *OpenID) RedirectURL(id, callbackURL, realm string) (string, error) {
-	return redirectURL(id, callbackURL, realm, oid.urlGetter)
-}
-
-func redirectURL(id, callbackURL, realm string, getter httpGetter) (string, error) {
-	opEndpoint, opLocalID, claimedID, err := discover(id, getter)
+	opEndpoint, opLocalID, claimedID, err := oid.Discover(id)
 	if err != nil {
 		return "", err
 	}

--- a/redirect.go
+++ b/redirect.go
@@ -6,7 +6,11 @@ import (
 )
 
 func RedirectURL(id, callbackURL, realm string) (string, error) {
-	return redirectURL(id, callbackURL, realm, urlGetter)
+	return defaultInstance.RedirectURL(id, callbackURL, realm)
+}
+
+func (oid *OpenID) RedirectURL(id, callbackURL, realm string) (string, error) {
+	return redirectURL(id, callbackURL, realm, oid.urlGetter)
 }
 
 func redirectURL(id, callbackURL, realm string, getter httpGetter) (string, error) {

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -70,7 +70,7 @@ func TestRedirectWithDiscovery(t *testing.T) {
 }
 
 func expectRedirect(t *testing.T, uri, callback, realm, exRedirect string, exErr bool) {
-	redirect, err := redirectURL(uri, callback, realm, testGetter)
+	redirect, err := testInstance.RedirectURL(uri, callback, realm)
 	if (err != nil) != exErr {
 		t.Errorf("Unexpected error: '%s'", err)
 		return

--- a/verify.go
+++ b/verify.go
@@ -13,10 +13,6 @@ func Verify(uri string, cache DiscoveryCache, nonceStore NonceStore) (id string,
 }
 
 func (oid *OpenID) Verify(uri string, cache DiscoveryCache, nonceStore NonceStore) (id string, err error) {
-	return verify(uri, cache, oid.urlGetter, nonceStore)
-}
-
-func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore NonceStore) (id string, err error) {
 	parsedURL, err := url.Parse(uri)
 	if err != nil {
 		return "", err
@@ -37,7 +33,7 @@ func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore Nonc
 	}
 
 	// - The signature on the assertion is valid (Section 11.4)
-	if err = verifySignature(uri, values, getter); err != nil {
+	if err = verifySignature(uri, values, oid.urlGetter); err != nil {
 		return "", err
 	}
 
@@ -49,7 +45,7 @@ func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore Nonc
 
 	// - Discovered information matches the information in the assertion
 	//   (Section 11.2)
-	if err = verifyDiscovered(parsedURL, values, cache, getter); err != nil {
+	if err = oid.verifyDiscovered(parsedURL, values, cache); err != nil {
 		return "", err
 	}
 
@@ -131,7 +127,7 @@ func compareQueryParams(q1, q2 url.Values) error {
 	return nil
 }
 
-func verifyDiscovered(uri *url.URL, vals url.Values, cache DiscoveryCache, getter httpGetter) error {
+func (oid *OpenID) verifyDiscovered(uri *url.URL, vals url.Values, cache DiscoveryCache) error {
 	version := vals.Get("openid.ns")
 	if version != "http://specs.openid.net/auth/2.0" {
 		return errors.New("Bad protocol version")
@@ -187,7 +183,7 @@ func verifyDiscovered(uri *url.URL, vals url.Values, cache DiscoveryCache, gette
 	// assertion), the Relying Party MUST perform discovery on the Claimed
 	// Identifier in the response to make sure that the OP is authorized to
 	// make assertions about the Claimed Identifier.
-	if ep, _, _, err := discover(claimedID, getter); err == nil {
+	if ep, _, _, err := oid.Discover(claimedID); err == nil {
 		if ep == endpoint {
 			// This claimed ID points to the same endpoint, therefore this
 			// endpoint is authorized to make assertions about that claimed ID.

--- a/verify.go
+++ b/verify.go
@@ -9,7 +9,11 @@ import (
 )
 
 func Verify(uri string, cache DiscoveryCache, nonceStore NonceStore) (id string, err error) {
-	return verify(uri, cache, urlGetter, nonceStore)
+	return defaultInstance.Verify(uri, cache, nonceStore)
+}
+
+func (oid *OpenID) Verify(uri string, cache DiscoveryCache, nonceStore NonceStore) (id string, err error) {
+	return verify(uri, cache, oid.urlGetter, nonceStore)
 }
 
 func verify(uri string, cache DiscoveryCache, getter httpGetter, nonceStore NonceStore) (id string, err error) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -102,7 +102,7 @@ func TestVerifyDiscovered(t *testing.T) {
 		"openid.identity":    []string{"http://example.com/openid/id/foo"}}
 
 	// Make sure we fail with no discovery handler
-	if err := verifyDiscovered(nil, vals, dc, testGetter); err == nil {
+	if err := testInstance.verifyDiscovered(nil, vals, dc); err == nil {
 		t.Errorf("verifyDiscovered succeeded unexpectedly with no discovery")
 	}
 
@@ -121,7 +121,7 @@ Content-Type: application/xrds+xml; charset=UTF-8
 </xrds:XRDS>`
 
 	// Make sure we succeed now
-	if err := verifyDiscovered(nil, vals, dc, testGetter); err != nil {
+	if err := testInstance.verifyDiscovered(nil, vals, dc); err != nil {
 		t.Errorf("verifyDiscovered failed unexpectedly: %v", err)
 	}
 
@@ -129,7 +129,7 @@ Content-Type: application/xrds+xml; charset=UTF-8
 	delete(testGetter.urls, "http://example.com/openid/id/foo#Accept#application/xrds+xml")
 
 	// Make sure we still succeed thanks to the discovery cache
-	if err := verifyDiscovered(nil, vals, dc, testGetter); err != nil {
+	if err := testInstance.verifyDiscovered(nil, vals, dc); err != nil {
 		t.Errorf("verifyDiscovered failed unexpectedly: %v", err)
 	}
 }


### PR DESCRIPTION
Unfortunately not every Go runtime environment has a functional `http.DefaultClient`, which is used by this library to do all the HTTP requests.

One such environment is [Google App Engine](https://en.wikipedia.org/wiki/Google_App_Engine). In addition to needing to use a custom `http.Client`, this custom client is also different on a per-request basis, so just exposing `urlGetter` isn't going to cut it.

My patch adds the ability to provide a custom `http.Client` on a per-instance basis, which is sufficient to fully support App Engine. The existing static functions now use a default instance under the hood.