### PR TITLE
Expose the BuildRedirectURL function

### DIFF
--- a/redirect.go
+++ b/redirect.go
@@ -14,10 +14,10 @@ func redirectURL(id, callbackURL, realm string, getter httpGetter) (string, erro
 	if err != nil {
 		return "", err
 	}
-	return buildRedirectURL(opEndpoint, opLocalID, claimedID, callbackURL, realm)
+	return BuildRedirectURL(opEndpoint, opLocalID, claimedID, callbackURL, realm)
 }
 
-func buildRedirectURL(opEndpoint, opLocalID, claimedID, returnTo, realm string) (string, error) {
+func BuildRedirectURL(opEndpoint, opLocalID, claimedID, returnTo, realm string) (string, error) {
 	values := make(url.Values)
 	values.Add("openid.ns", "http://specs.openid.net/auth/2.0")
 	values.Add("openid.mode", "checkid_setup")

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -43,7 +43,7 @@ func TestBuildRedirectUrl(t *testing.T) {
 }
 
 func expectURL(t *testing.T, opEndpoint, opLocalID, claimedID, returnTo, realm, expected string) {
-	url, err := buildRedirectURL(opEndpoint, opLocalID, claimedID, returnTo, realm)
+	url, err := BuildRedirectURL(opEndpoint, opLocalID, claimedID, returnTo, realm)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
I have a situation where I need to support only already-known OP endpoints, so I can skip the discovery part of building the redirect URL.

This patch exposes the `BuildRedirectURL` function to facilitate this.