### PR TITLE
Support openid2.provider in self-closing tags

### DIFF
--- a/html_discovery.go
+++ b/html_discovery.go
@@ -30,7 +30,7 @@ func findProviderFromHeadLink(input io.Reader) (opEndpoint, opLocalID string, er
 				return
 			}
 			return "", "", tokenizer.Err()
-		case html.StartTagToken, html.EndTagToken:
+		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
 			tk := tokenizer.Token()
 			if tk.Data == "head" {
 				if tt == html.StartTagToken {

--- a/html_discovery_test.go
+++ b/html_discovery_test.go
@@ -19,6 +19,15 @@ func TestFindEndpointFromLink(t *testing.T) {
         </head>
       </html>
       `, "foo.com", "bar-name", false)
+	// Self-closing link
+	searchLink(t, `
+      <html>
+        <head>
+          <link rel="openid2.provider" href="selfclose.com" />
+          <link rel="openid2.local_id" href="selfclose-name" />
+        </head>
+      </html>
+      `, "selfclose.com", "selfclose-name", false)
 }
 
 func TestNoEndpointFromLink(t *testing.T) {


### PR DESCRIPTION
These are found in the wild (like in my own openid)
If you want to test: https://strk.kbt.io/openid/