### PR TITLE
Revert back to explicit import in the integration test

### DIFF
--- a/integration/discovery_test.go
+++ b/integration/discovery_test.go
@@ -5,7 +5,7 @@ package integration
 // whatever, they will fail. It's ok though, they are full tests.
 
 import (
-	. "../"
+	. "github.com/yohcop/openid-go"
 	"testing"
 )
 


### PR DESCRIPTION
I originally changed this to relative import with #36 in order to easily test without using GOPATH.

Relative imports in Go are a peculiar thing. They aren't advertised as even existing and are a historical quirk that predates the concept of GOPATH. There have been [suggestions to ban](https://github.com/golang/go/issues/6147) the usage of them, although that ended with *we should keep the limited support* and [there are tests for it](https://golang.org/src/cmd/go/testdata/local/easysub/main.go) working in the Go compiler.

In practice it kept working for me until today when it suddenly stopped. Now I get linker errors, similar to what was [reported here](https://github.com/golang/go/issues/14683).

Because relative imports aren't properly supported and have seemingly random linker errors at times I think we should move back to an explict import. This requires GOPATH usage, but that's not the end of the world and in return will give us much more predictable behavior.