### PR TITLE
Fix XRI Cross-Reference URI detection

### DIFF
--- a/normalizer.go
+++ b/normalizer.go
@@ -25,7 +25,7 @@ func Normalize(id string) (string, error) {
 	// Global Context Symbol ("=", "@", "+", "$", "!") or "(", as
 	// defined in Section 2.2.1 of [XRI_Syntax_2.0], then the input
 	// SHOULD be treated as an XRI.
-	if b := id[0]; b == '=' || b == '@' || b == '+' || b == '$' || b == '!' {
+	if b := id[0]; b == '=' || b == '@' || b == '+' || b == '$' || b == '!' || b == '(' {
 		return id, errors.New("XRI identifiers not supported")
 	}
 

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -13,6 +13,7 @@ func TestNormalize(t *testing.T) {
 	doNormalize(t, "http://example.com/user/", "http://example.com/user/", true)
 	doNormalize(t, "http://example.com/", "http://example.com/", true)
 	doNormalize(t, "=example", "=example", false)       // XRI not supported
+	doNormalize(t, "(=example)", "(=example)", false)   // XRI not supported
 	doNormalize(t, "xri://=example", "=example", false) // XRI not supported
 
 	// Empty


### PR DESCRIPTION
Both [OpenID 2.0 spec point 7.2](http://openid.net/specs/openid-authentication-2_0.html#normalization) and [XRI 2.0 spec point 2.2.2](https://www.oasis-open.org/committees/download.php/15376#_Toc117301850) mention the cross-reference mechanism of XRI where the URI starts with an open parenthesis. Indeed this was even mentioned in the pasted spec text that was above the affected code line.

This PR fixes the omission and adds a test for it.