### PR TITLE
Add Go modules support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,19 @@ sudo: false
 language: go
 
 go:
- - 1.3.3
- - 1.4.2
- - 1.5.2
- - 1.6beta2
+ - 1.3.x
+ - 1.4.x
+ - 1.5.x
+ - 1.6.x
+ - 1.7.x
+ - 1.8.x
+ - 1.9.x
+ - 1.10.x
+ - 1.11.x
+ - 1.12.x
+
+env:
+ - GO111MODULE=on
 
 # Get deps, build, test, and ensure the code is gofmt'ed.
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/yohcop/openid-go
+
+go 1.3
+
+require golang.org/x/net v0.0.0-20190522155817-f3200d17e092

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/nonce_store.go
+++ b/nonce_store.go
@@ -55,7 +55,7 @@ func (d *SimpleNonceStore) Accept(endpoint, nonce string) error {
 	now := time.Now()
 	diff := now.Sub(ts)
 	if diff > *maxNonceAge {
-		return fmt.Errorf("Nonce too old: %ds", diff.Seconds())
+		return fmt.Errorf("Nonce too old: %.2fs", diff.Seconds())
 	}
 
 	s := nonce[20:]


### PR DESCRIPTION
### Support for modules
This PR adds the `go.mod` and `go.sum` files needed to define dependencies in the new [Go modules system](https://github.com/golang/go/wiki/Modules).

### Travis CI
I'm not very familiar with Travis, but I updated the config file based on some quick reading of [their documentation](https://docs.travis-ci.com/user/languages/go/). Hopefully it works.

### Minor bugfix
Go 1.11 was complaining about `Errorf format %d has arg diff.Seconds() of wrong type float64`. I checked the Go 1.3 stdlib source and it was always `float64`. I guess the warning is new. In any case, I fixed the issue.

### Steps to take after merging
After this has been merged, please [tag the latest commit with semver](https://github.com/golang/go/wiki/Modules#modules). `v1.0.0` sounds good to me.