### PR TITLE
Fix discovery of self-closing X-XRDS-Location meta tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yohcop/openid-go
+module github.com/Schrodinger-Box/openid-go
 
 go 1.3
 

--- a/yadis_discovery.go
+++ b/yadis_discovery.go
@@ -90,7 +90,7 @@ func findMetaXrdsLocation(input io.Reader) (location string, err error) {
 		switch tt {
 		case html.ErrorToken:
 			return "", tokenizer.Err()
-		case html.StartTagToken, html.EndTagToken:
+		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
 			tk := tokenizer.Token()
 			if tk.Data == "head" {
 				if tt == html.StartTagToken {


### PR DESCRIPTION
Some identity provider websites use XHTML doctype which enforces the use of `/>` even for meta tags. This is not recognized by this program and lead to the site not being recognized/discovered and errors are thrown,